### PR TITLE
Rmenr/restart fixes

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -71,7 +71,10 @@ else
   end
 end
 
+## if service memcached disabled/not running,do
 service 'memcached' do
   action [:enable, :start]
   supports status: true, start: true, stop: true, restart: true, enable: true
 end
+
+## ELSE, do action [:restart]

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -72,7 +72,3 @@ end
 
 # if (node.attribute?('something') && ! FileTest.directory?(node['memcached']['config_path']))
 # if File.readlines("/etc/memcached").grep(/Chef/).any?  -- so what's the opposite of this?
-
-service 'memcached' do
-  action [:stop, :disable]
-end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -64,8 +64,15 @@ user service_user do
   action :nothing
 end
 
+## THIS IS WHAT STOPS THE SERVICE, NO MATTER WHAT
 # Disable the default memcached service so we configure it from the custom resource
 # If the memcached::default is included the configure.rb recipe will start/enable the service
+
+# unless /etc/memcached.conf contains "managed by chef", do
+
+# if (node.attribute?('something') && ! FileTest.directory?(node['memcached']['config_path']))
+# if File.readlines("/etc/memcached").grep(/Chef/).any?  -- so what's the opposite of this?
+
 service 'memcached' do
   action [:stop, :disable]
 end


### PR DESCRIPTION
We don't want to disable memcached if/when installing the package. It appears to notify a restart. 

In our case, we don't use this cookbook on ec2 hosts where an existing "system" memcached package resides, so disabling the "system-installed" package shouldn't be a worry/concern for us. 
